### PR TITLE
Update README to reflect the correct environment variable for OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ require "lammy"
 
 ## Usage
 
-We currently support OpenAI's models and Anthropic's Claude. You can use any model that supports the OpenAI API or Claude. Make sure to set the `OPENAI_API_KEY` environment variable for OpenAI models or the `ANTHROPIC_API_KEY` for Claude models.
+We currently support OpenAI's models and Anthropic's Claude. You can use any model that supports the OpenAI API or Claude. Make sure to set the `OPENAI_ACCESS_TOKEN` environment variable for OpenAI models or the `ANTHROPIC_API_KEY` for Claude models.
 
 ### Chat
 


### PR DESCRIPTION
I've updated the README to correctly reflect the environment variable used for OpenAI's access token. But since Anthropic uses `ANTHROPIC_API_KEY`, maybe you want OpenAI to use `OPENAI_API_KEY`? But this would be a breaking change, so maybe you support both?  Let me know if you'd like me to implement support for both environment variables.